### PR TITLE
Update _default.yml

### DIFF
--- a/vars/_default.yml
+++ b/vars/_default.yml
@@ -1,6 +1,6 @@
 # vars file
 ---
-tinyproxy_configuration_file: /etc/tinyproxy.conf
+tinyproxy_configuration_file: /etc/tinyproxy/tinyproxy.conf
 
 tinyproxy_tinyproxy_conf_preset:
   - |


### PR DESCRIPTION
for your consideration...

reading the tinyproxy man page, the default locations tinyproxy checks for configuration is: `/etc/tinyproxy/tinyproxy.conf`, `/var/run/tinyproxy/tinyproxy.pid`, `/var/log/tinyproxy/tinyproxy.log`

When running this playbook on an OS that does not have a specific configuration listed in the vars folder, the config file is created at a location that tinyproxy when run as a service, is not picked up, and the service runs with the default configuration that comes with the package install.

is there some other reason the default is in this location? otherwise, I think we need to merge https://github.com/Oefenweb/ansible-tinyproxy/pull/3 so that it can be overridden by users.